### PR TITLE
Minor update

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Write simple and modular code and order your function code: **conditions**, **ac
 ### control statements
 - for *loop*
   - Consider reviewing all for-loops and ensure that array maximum lengths are checked on iteration.
+  - Consider the situation where loop exits out of gas.
+  - Make sure that increment variable does not overflow.
 
 ### naming
 - Naming with clear meaning

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ Write simple and modular code and order your function code: **conditions**, **ac
 
 ### naming
 - Naming with clear meaning
-- It is recommended that the name of the `contract` and the name of the `function` be different.
 - It is recommended that the name of the `event` and the name of the `function` be different.
 
 ### etc


### PR DESCRIPTION
Add 2 check lists for "for loop" and remove naming convention.


##### naming
Constructor of a contract has same name with the contract.
